### PR TITLE
More information when push fails, turn off pipefail

### DIFF
--- a/macos_notarize.sh
+++ b/macos_notarize.sh
@@ -61,7 +61,7 @@ while true; do
     esac
 done
 
-set -o nounset pipefail
+set -o nounset
 
 pushd ${TARGET_BINARY%/*} >/dev/null
 trap "popd >/dev/null" EXIT
@@ -77,8 +77,7 @@ fi
 SUBMISSION_INFO=$(xcrun altool --notarize-app --primary-bundle-id=${PRIMARY_BUNDLE_ID} -u ${APPLE_ID} -p ${APP_SPECIFIC_PASSWORD} --file ${TARGET_BINARY}.zip 2>&1) ;
 
 if [ $? != 0 ]; then
-    echo "Submission failed:"
-    echo $SUBMISSION_INFO
+    printf "Submission failed: $SUBMISSION_INFO \n"
     exit 5
 fi
 


### PR DESCRIPTION
The nightly build recently started failing. 
But the failure in circleci didn't give enough info:

```
not ok 2 Notarize a signed dummy binary
# (in test file tests/02_macos_notarize.bats, line 21)
#   `./macos_notarize.sh  --app-specific-password=${APP_SPECIFIC_PASSWORD} --apple-id=${APPLE_ID} --primary-bundle-id=com.ddev.test-signing-tools --target-binary=${TARGET_BINARY}' failed with status 24
# Signing /tmp/macos_notarize_dummy
# Signed /tmp/macos_notarize_dummy with Developer ID Application: DRUD Technology, LLC (3BAN66AG5M)
make: *** [test] Error 1
```

It turned out that Apple had changed their contracts yet again. Here's what was coming through:

```
1 package(s) were not uploaded because they had problems:
	/var/folders/q7/gr99xnnd67bg00r_sb75rhtm0000gn/T/89B596E3-5F16-4C52-A451-303AE2E1C9F2/com.ddev.test-signing-tools.itmsp - Error Messages:
		You must first sign the relevant contracts online. (1048)
2020-01-27 06:31:54.382 altool[19850:7357138] *** Error: You must first sign the relevant contracts online. (1048)
```

I had to go to https://appstoreconnect.apple.com/agreements/#/ and sign some weird thing they'd changed.  That should have solved it. But we should have been able to see that in the original test failure.

