### PR TITLE
Update notarization for signing_tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,14 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
-        context: org-global
+      - build:
+          context: org-global
 
 
   nightly_build:
     jobs:
-      - build
-        context: org-global
+      - build:
+          context: org-global
     triggers:
       - schedule:
           cron: "0 3 * * *"
@@ -41,7 +41,7 @@ workflows:
   tag_build:
     jobs:
       - build:
-        context: org-global
+          context: org-global
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     macos:
@@ -18,33 +18,31 @@ jobs:
         no_output_timeout: 30m
 
 workflows:
-  version: 2
   build:
-    jobs:
-      - build:
-          context: org-global
-
+    - hold:
+        type: approval
+    - build:
+        requires:
+          -hold
+        context: org-global
 
   nightly_build:
-    jobs:
-      - build:
-          context: org-global
     triggers:
       - schedule:
           cron: "0 3 * * *"
           filters:
             branches:
               only:
-                - master
-                - "pull/[0-9]+"
-
+              - master
+              - "pull/[0-9]+"
+    - build:
+        context: org-global
   tag_build:
-    jobs:
-      - build:
-          context: org-global
-          filters:
-            tags:
-              only:
-                - "/.*/"
-            branches:
-              ignore: /.*/
+    - build:
+        context: org-global
+        filters:
+          tags:
+            only:
+              - "/.*/"
+          branches:
+            ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,8 @@ version: 2.1
 workflows:
   build_and_test:
     jobs:
-      - hold:
-          type: approval
       - build:
-          requires:
-            - hold
-          context: org-global
+          context: signing_tools
 
   nightly_build:
     triggers:
@@ -21,7 +17,7 @@ workflows:
               - "pull/[0-9]+"
     jobs:
       - build:
-          context: org-global
+          context: signing_tools
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,13 @@ workflows:
   build:
     jobs:
       - build
+        context: org-global
+
 
   nightly_build:
     jobs:
       - build
+        context: org-global
     triggers:
       - schedule:
           cron: "0 3 * * *"
@@ -38,6 +41,7 @@ workflows:
   tag_build:
     jobs:
       - build:
+        context: org-global
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,28 @@
 version: 2.1
+
+workflows:
+  build_and_test:
+    jobs:
+      - hold:
+          type: approval
+      - build:
+          requires:
+            - hold
+          context: org-global
+
+  nightly_build:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+              - master
+              - "pull/[0-9]+"
+    jobs:
+      - build:
+          context: org-global
+
 jobs:
   build:
     macos:
@@ -17,32 +41,4 @@ jobs:
         command: make test
         no_output_timeout: 30m
 
-workflows:
-  build:
-    - hold:
-        type: approval
-    - build:
-        requires:
-          -hold
-        context: org-global
 
-  nightly_build:
-    triggers:
-      - schedule:
-          cron: "0 3 * * *"
-          filters:
-            branches:
-              only:
-              - master
-              - "pull/[0-9]+"
-    - build:
-        context: org-global
-  tag_build:
-    - build:
-        context: org-global
-        filters:
-          tags:
-            only:
-              - "/.*/"
-          branches:
-            ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -73,3 +73,11 @@ Signing and Notarizing are implemented in [DDEV-Local's Makefile](https://github
 * [Signing without the popup password](https://stackoverflow.com/a/40039594/215713) (for CI, same SO question)
 * [Apple's Code Signing docs](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html)
 * [Common Code Signing Errors](https://medium.com/@SharpFive/common-code-signing-errors-codesign-failed-with-exit-code-1-1ffa5f4785c9)
+
+## Developer and Contribution information
+
+* If you're making changes, use `make test` to test them. You'll need these environment variables set
+    * APPLE_ID (the apple username/email related to the APP_SPECIFIC_PASSWORD)
+    * APP_SPECIFIC_PASSWORD (Apple app specific password)
+    * SIGNING_TOOLS_SIGNING_PASSWORD (signing password for the provided certificate).
+* For now, forked PRs will not run tests in this repo, because they could expose the APP_SPECIFIC_PASSWORD. In the future, we can use a technique [like this](https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/4) to separate forked PRs from direct PRs, and add a hold step in the forked-PR path. See the [hold technique](https://circleci.com/docs/2.0/contexts/#approving-jobs-that-use-restricted-contexts) in CircleCI docs.

--- a/dummy.txt
+++ b/dummy.txt
@@ -1,0 +1,2 @@
+
+another try

--- a/dummy.txt
+++ b/dummy.txt
@@ -1,2 +1,0 @@
-
-another try

--- a/macos_notarize.sh
+++ b/macos_notarize.sh
@@ -104,7 +104,8 @@ timeout 10m bash -c "
 # Get logfileurl and make sure it doesn't have any issues
 logfileurl=$(xcrun altool --notarization-info $REQUEST_UUID --username ${APPLE_ID} --password ${APP_SPECIFIC_PASSWORD} --output-format xml | xq .plist.dict.dict.string[1] | xargs)
 echo "Notarization LogFileURL=$logfileurl for REQUEST_UUID=$REQUEST_UUID ";
-issues=$(curl -s $logfileurl | jq -r .issues)
+issues=$(curl -sSL $logfileurl | jq -r .issues)
+set -x
 if [ "$issues" != "null" ]; then
     printf "There are issues with the notarization, see  $logfileurl\n$issues"
     exit 7;

--- a/macos_notarize.sh
+++ b/macos_notarize.sh
@@ -104,9 +104,10 @@ timeout 10m bash -c "
 # Get logfileurl and make sure it doesn't have any issues
 logfileurl=$(xcrun altool --notarization-info $REQUEST_UUID --username ${APPLE_ID} --password ${APP_SPECIFIC_PASSWORD} --output-format xml | xq .plist.dict.dict.string[1] | xargs)
 echo "Notarization LogFileURL=$logfileurl for REQUEST_UUID=$REQUEST_UUID ";
-issues=$(curl -sSL $logfileurl | jq -r .issues)
-set -x
+log=$(curl -sSL $logfileurl)
+issues=$(echo ${log} | jq -r .issues )
 if [ "$issues" != "null" ]; then
-    printf "There are issues with the notarization, see  $logfileurl\n$issues"
+    printf "There are issues with the notarization (${issues}), see $logfileurl\n"
+    printf "=== Log output === \n${log}\n"
     exit 7;
 fi;


### PR DESCRIPTION
We had to redo our Apple passwords for multiple reasons, so reviewing, this puts the actual app-specific password into the org-global context, which is not accessible to outside-the-org forks. 

## TODO
- [x] Use a context specific to this project, with only environment variables that belong here.
- [x] Update README with contribution techniques and optional future paths for PRs from forks