### PR TITLE
Make scripts work on arm64 homebrew - use brew --prefix

### DIFF
--- a/macos_notarize.sh
+++ b/macos_notarize.sh
@@ -3,8 +3,8 @@
 set -eu -o pipefail
 
 OS=$(uname -s)
-if [ ${OS} = "Darwin" ]; then PATH="/usr/local/opt/gnu-getopt/bin:$PATH"; fi
-if [ ${OS} = "Darwin" ] && [ ! -f "/usr/local/opt/gnu-getopt/bin/getopt" ]; then
+if [ ${OS} = "Darwin" ]; then PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"; fi
+if [ ${OS} = "Darwin" ] && [ ! -f "$(brew --prefix)/opt/gnu-getopt/bin/getopt" ]; then
     echo "This script requires 'brew install gnu-getopt'" && exit 1
 fi
 

--- a/macos_sign.sh
+++ b/macos_sign.sh
@@ -3,8 +3,8 @@
 set -o errexit
 
 OS=$(uname -s)
-if [ ${OS} = "Darwin" ]; then PATH="/usr/local/opt/gnu-getopt/bin:$PATH"; fi
-if [ ${OS} = "Darwin" ] && [ ! -f "/usr/local/opt/gnu-getopt/bin/getopt" ]; then
+if [ ${OS} = "Darwin" ]; then PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"; fi
+if [ ${OS} = "Darwin" ] && [ ! -f "$(brew --prefix)/opt/gnu-getopt/bin/getopt" ]; then
     echo "This script requires 'brew install gnu-getopt'" && exit 1
 fi
 


### PR DESCRIPTION
I tried to run the scripts on mac M1... and there's a flaw. Needs to use `brew --prefix` instead of hard-wired /usr/local.