### PR TITLE
Add keepalive-workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,4 @@ jobs:
           SIGNING_TOOLS_SIGNING_PASSWORD: ${{ secrets.SIGNING_TOOLS_SIGNING_PASSWORD }}
         run: |
           make test
+      - uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
Github Actions automatically turns off tests for repos with no commits for 60 days. Ugly. Use keepalive-workflow to beat this, https://github.com/gautamkrishnar/keepalive-workflow