### PR TITLE
Use homebrew action to make sure brew is there

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - uses: actions/setup-go@v2
       - run: |
           brew install bats-core coreutils gnu-getopt jq


### PR DESCRIPTION
homebrew now often has to be explicitly installed. Add it.  Probably doesn't matter here on macOS, but we've been seeing complaints about xq.