### PR TITLE
chore(*): macos-26, use bats libraries, bump actions, for ddev/ddev#8450

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           go-version: '>=1.23'
           check-latest: true
+          cache: false
       - name: Load 1Password secrets for signing tools
         uses: 1password/load-secrets-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 on:
   push:
+    branches: [ master, main ]
+  pull_request:
   schedule:
     - cron: '0 3 * * *'
 
@@ -11,6 +13,10 @@ on:
         description: Debug with tmate
         required: false
         default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   actions: write
@@ -28,15 +34,16 @@ jobs:
 
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '^1.20'
+          go-version: '>=1.23'
+          check-latest: true
       - name: Load 1Password secrets for signing tools
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@v4
         with:
           export-env: true
         env:
@@ -49,8 +56,7 @@ jobs:
           echo "APP_SPECIFIC_PASSWORD set: $([ -n "${APP_SPECIFIC_PASSWORD}" ] && echo "yes" || echo "no")"
           echo "SIGNING_TOOLS_SIGNING_PASSWORD set: $([ -n "${SIGNING_TOOLS_SIGNING_PASSWORD}" ] && echo "yes" || echo "no")"
       - run: |
-          brew tap bats-core/bats-core
-          brew install bats-core gnu-getopt jq xq yq
+          brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support gnu-getopt jq xq yq
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
@@ -63,4 +69,3 @@ jobs:
             echo "Running ${item}"
             bats "${item}"
           done
-      # - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       run:
         shell: bash
 
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - name: Set up Homebrew

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,6 @@ jobs:
           echo "APP_SPECIFIC_PASSWORD set: $([ -n "${APP_SPECIFIC_PASSWORD}" ] && echo "yes" || echo "no")"
           echo "SIGNING_TOOLS_SIGNING_PASSWORD set: $([ -n "${SIGNING_TOOLS_SIGNING_PASSWORD}" ] && echo "yes" || echo "no")"
       - name: Install dependencies
-        env:
-          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         run: |
           brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support gnu-getopt jq xq yq
       - name: Setup tmate session

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,10 @@ jobs:
           echo "APPLE_ID: ${APPLE_ID}"
           echo "APP_SPECIFIC_PASSWORD set: $([ -n "${APP_SPECIFIC_PASSWORD}" ] && echo "yes" || echo "no")"
           echo "SIGNING_TOOLS_SIGNING_PASSWORD set: $([ -n "${SIGNING_TOOLS_SIGNING_PASSWORD}" ] && echo "yes" || echo "no")"
-      - run: |
+      - name: Install dependencies
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
+        run: |
           brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support gnu-getopt jq xq yq
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![tests](https://github.com/ddev/signing_tools/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/ddev/signing_tools/actions/workflows/test.yml?query=branch%3Amaster)
 [![last commit](https://img.shields.io/github/last-commit/ddev/signing_tools)](https://github.com/ddev/signing_tools/commits)
 
 # signing_tools: macOS Signing and Notarization Tools

--- a/tests/01_macos_sign.bats
+++ b/tests/01_macos_sign.bats
@@ -9,15 +9,20 @@ TARGET_BINARY=/tmp/macos_sign_bats_dummy
 
 # SIGNING_TOOLS_SIGNING_PASSWORD must be set by test runner
 
-function setup {
+setup() {
+    load setup.sh
     rm -f ${TARGET_BINARY}
     go build -o ${TARGET_BINARY} tests/testdata/helloworld.go
 }
 
 @test "Sign a dummy binary" {
-    ./macos_sign.sh --signing-password="${SIGNING_TOOLS_SIGNING_PASSWORD}" --cert-file=${CERTFILE} --cert-name="${CERTNAME}" --target-binary="${TARGET_BINARY}"
-    codesign -vv ${TARGET_BINARY}
-    codesign -vv -d ${TARGET_BINARY} 2>&1 | grep "$CERTNAME"
+    run ./macos_sign.sh --signing-password="${SIGNING_TOOLS_SIGNING_PASSWORD}" --cert-file=${CERTFILE} --cert-name="${CERTNAME}" --target-binary="${TARGET_BINARY}"
+    assert_success
+
+    run codesign -vv ${TARGET_BINARY}
+    assert_success
+
+    run codesign -vv -d "${TARGET_BINARY}"
+    assert_success
+    assert_output --partial "${CERTNAME}"
 }
-
-

--- a/tests/02_macos_notarize.bats
+++ b/tests/02_macos_notarize.bats
@@ -12,14 +12,14 @@ TARGET_BINARY=/tmp/macos_notarize_dummy
 # APPLE_ID should come from environment variable
 TEAM_ID="9HQ298V2BW"
 
-function setup {
+setup() {
+    load setup.sh
     rm -f ${TARGET_BINARY}
     go build -o ${TARGET_BINARY} tests/testdata/helloworld.go
     ./macos_sign.sh --signing-password="${SIGNING_TOOLS_SIGNING_PASSWORD}" --cert-file=${CERTFILE} --cert-name="${CERTNAME}" --target-binary="${TARGET_BINARY}"
 }
 
 @test "Notarize a signed dummy binary" {
-    ./macos_notarize.sh  --app-specific-password=${APP_SPECIFIC_PASSWORD} --apple-id=${APPLE_ID} --team-id=${TEAM_ID} --primary-bundle-id=com.ddev.test-signing-tools --target-binary=${TARGET_BINARY}
+    run ./macos_notarize.sh --app-specific-password=${APP_SPECIFIC_PASSWORD} --apple-id=${APPLE_ID} --team-id=${TEAM_ID} --primary-bundle-id=com.ddev.test-signing-tools --target-binary=${TARGET_BINARY}
+    assert_success
 }
-
-

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support
+
+bats_require_minimum_version 1.11.0
+set -eu -o pipefail
+TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+export BATS_LIB_PATH="${BATS_LIB_PATH:-}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+bats_load_library bats-assert
+bats_load_library bats-file
+bats_load_library bats-support


### PR DESCRIPTION
## The Issue

- For https://github.com/ddev/ddev/issues/8450

## How This PR Solves The Issue

- Switches from `macos-15` to `macos-26`
- Uses bats libraries
- Bumps all actions

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

